### PR TITLE
Clock css breaks on phone screen

### DIFF
--- a/src/styles/block_mixin.scss
+++ b/src/styles/block_mixin.scss
@@ -2,6 +2,7 @@
 
 @mixin default-block {
     background-color: $second-color;
+    aspect-ratio: 1/1;
     
     width: 20rem;
     height: 20rem;


### PR DESCRIPTION
Fixes #1
adds aspect ratio to all blocks by default, this should keep all of the blocks uniform